### PR TITLE
Removed padding around menu bar

### DIFF
--- a/share/pulseaudio-equalizer/pulseaudio-equalizer.py
+++ b/share/pulseaudio-equalizer/pulseaudio-equalizer.py
@@ -413,7 +413,7 @@ class Equalizer:
         self.window.add(vbox1)
         vbox1.show()
         menu_bar = gtk.MenuBar()
-        vbox1.pack_start(menu_bar, False, False, 2)
+        vbox1.pack_start(menu_bar, False, False, 0)
         menu_bar.show()
         menu_bar.append(root_menu)
 


### PR DESCRIPTION
There was a two pixel padding around the menu bar and the one at the top didn't seem right, so I removed it entirely. If that was indeed a bug and not a feature, I'd be happy if that change would be merged - I'm sure there are other people who are at least as irritated by that gap as I am :D 